### PR TITLE
[issue-9] support for secure connection to pravega

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ output {
       pravega_endpoint => "tcp://<host>:<port>"
       stream_name => "myStream"
       scope => "myScope"
+      #username => "admin"
+      #password => "1111_aaaa"
     }
   }
 }

--- a/logstash-output-pravega.gemspec
+++ b/logstash-output-pravega.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   # Special flag to let us know this is actually a logstash plugin
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
-  s.requirements << "jar 'io.pravega:pravega-client', '0.3.0-SNAPSHOT'"
+  s.requirements << "jar 'io.pravega:pravega-client', '0.3.0-64.d0c8497-SNAPSHOT'"
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"

--- a/logstash-output-pravega.gemspec
+++ b/logstash-output-pravega.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-output-pravega'
-  s.version       = '0.2.0'
+  s.version       = '0.3.0-SNAPSHOT'
   s.licenses      = ['Apache License (2.0)']
   s.summary       = 'Output events to a Pravega Stream. This uses the Pravega Writer API to write event to a stream on the Pravega'
   s.description   = 'This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program'
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   # Special flag to let us know this is actually a logstash plugin
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
-  s.requirements << "jar 'io.pravega:pravega-client', '0.1.0-SNAPSHOT'"
+  s.requirements << "jar 'io.pravega:pravega-client', '0.3.0-SNAPSHOT'"
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"

--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,13 @@
   <artifactId>dummy</artifactId>
   <version>0.0.0</version>
   <dependencies>
+    <!--
     <dependency>
       <groupId>io.pravega</groupId>
       <artifactId>pravega-client</artifactId>
-      <version>0.1.0-SNAPSHOT</version>
+      <version>0.3.0-SNAPSHOT</version>
     </dependency>
+    -->
   </dependencies>
   <repositories>
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -5,18 +5,21 @@
   <artifactId>dummy</artifactId>
   <version>0.0.0</version>
   <dependencies>
-    <!--
     <dependency>
       <groupId>io.pravega</groupId>
       <artifactId>pravega-client</artifactId>
-      <version>0.3.0-SNAPSHOT</version>
+      <version>0.3.0-64.d0c8497-SNAPSHOT</version>
     </dependency>
-    -->
   </dependencies>
   <repositories>
     <repository>
       <id>sonatype</id>
       <url>https://oss.sonatype.org/content/repositories/snapshots</url>
     </repository>
+    <repository>
+      <id>jfrog</id>
+      <url>https://oss.jfrog.org/artifactory/jfrog-dependencies</url>
+    </repository>
   </repositories>
 </project>
+


### PR DESCRIPTION
**Change log description**
- Add support for secure connection to pravega
- Update dependency to Pravega 0.3.0 snapshot

**Purse of the change**
Fixes #9 

**What the code does**
- Enable secure connection to pravega

**How to verify it**
- start pravega standalone in secure mode (enable authentication)
- build the plugin and install to logstash
- start logstash with pravega configuration
- upone successful start, the corresponding scope/stream should have been created in pravega
- stream more data to logstash and verify in pravega