### PR TITLE
update pravega client to latest

### DIFF
--- a/logstash-output-pravega.gemspec
+++ b/logstash-output-pravega.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   # Special flag to let us know this is actually a logstash plugin
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
-  s.requirements << "jar 'io.pravega:pravega-client', '0.3.0-64.d0c8497-SNAPSHOT'"
+  s.requirements << "jar 'io.pravega:pravega-client', '0.3.0-50.fe10b1d-SNAPSHOT'"
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <dependency>
       <groupId>io.pravega</groupId>
       <artifactId>pravega-client</artifactId>
-      <version>0.3.0-64.d0c8497-SNAPSHOT</version>
+      <version>0.3.0-50.fe10b1d-SNAPSHOT</version>
     </dependency>
   </dependencies>
   <repositories>


### PR DESCRIPTION
**Change log description**
- update pravega client version to latest snapshot as the specified one in pom/gemspec no longer exists.

**Purpose of the change**
- fixes #14 

**What the code does**
- Update pravega client version to 0.3.0-50.fe10b1d-SNAPSHOT

**How to verify it**
- follow the build instruction and verify the plugin can be successfully built.