### PR TITLE
issue17: upgrade output plugin to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,9 @@
+## 0.4.0
+  - Switch the version of pravega-client API to 0.4.0
+  - Fix some bugs of the old version
+      - Add the argument precheck for output plugin
+      - Fix the unnecessary filter again when input_stream is same as outout_stream
+      - Fix the bug of writer which can't handle the next round of data ingestion.
+
 ## 0.1.0
   - Plugin created with the logstash plugin generator

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,6 +4,7 @@ reports, or in general have helped logstash along its way.
 Contributors:
 * Ben Wang - ben.wang@emc.com
 * Tony Li  - tony.li@emc.com
+* Lingling Yao - Lingling.Yao@dell.com
 
 Note: If you've sent us patches, bug reports, or otherwise contributed to
 Logstash, and you aren't on the list above and want to be, please let us know

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Logstash Plugin
+# Logstash Output Pravage Plugin
 
 This is a plugin for [Logstash](https://github.com/elastic/logstash).
 
@@ -11,42 +11,46 @@ Logstash provides infrastructure to automatically generate documentation for thi
 - For formatting code or config example, you can use the asciidoc `[source,ruby]` directive
 - For more asciidoc formatting tips, see the excellent reference here https://github.com/elastic/docs#asciidoc-guide
 
+The logstash-output-pravega plugin is upgraded to version: 0.4.0. It can be used to write data to [pravage-0.4.0](https://github.com/pravega/pravega/releases).
+
 ## Need Help?
 
 Need help? Try #logstash on freenode IRC or the https://discuss.elastic.co/c/logstash discussion forum.
 
 ## Usage
+- First, have rvm installed. Take how to install it on ubuntu-18~18.04.1 for example. For other OS, find it's installation in [rvm install](https://rvm.io/rvm/install)
+```sh
+sudo apt-get install software-properties-common
+sudo apt-add-repository -y ppa:rael-gc/rvm
+sudo apt-get update
+sudo apt-get install -y rvm
+```
 
-- Have JRuby with the Bundler gem and mvn installed
+- Have JRuby with the Bundler gem and mvn installed. It's suggested to install the latest version jrbuy as the old version has bugs.
+```sh
+rvm install jruby-9.1.17.0
+rvm use jruby-9.1.17.0
+gem install bundler
+```
+
 - Install dependencies
 ```sh
 bundle install
 ```
+
 - Install pravega client library
 ```sh
-jrake install_jars
+gem install rake
+rake install_jars
 ```
 - Build pravega output plugin (`logstash-output-pravega-<version>.gem` shall be generated at project root directory)
-```
-jgem build logstash-output-pravega.gemspec
+```sh
+gem build logstash-output-pravega.gemspec
 ```
 - Install plugin: ship `logstash-output-pravega-<version>.gem` to target host where logstash is installed
+```sh
+sudo bin/logstash-plugin install logstash-output-pravega-<version>.gem
 ```
-logstash-plugin install logstash-output-pravega-<version>.gem
-```
-
-- NOTE: Resolve jar version conflict (only if you also want to use beats plugin). It's a known issue for logstash. To fix it, we need to replace netty-all jar in beats plugin by the one in pravega plugin
-```
-e.g.
-$ pwd
-/usr/local/Cellar/logstash/5.5.2
-$ find . -name netty-all-*.Final.jar
-./libexec/vendor/bundle/jruby/1.9/gems/logstash-input-beats-3.1.23-java/vendor/jar-dependencies/io/netty/netty-all/4.1.3.Final/netty-all-4.1.3.Final.jar
-./libexec/vendor/local_gems/4f0cb3fe/logstash-output-pravega-0.2.0/vendor/jar-dependencies/runtime-jars/netty-all-4.1.8.Final.jar
-
-$ cp ./libexec/vendor/local_gems/4f0cb3fe/logstash-output-pravega-0.2.0/vendor/jar-dependencies/runtime-jars/netty-all-4.1.8.Final.jar ./libexec/vendor/bundle/jruby/1.9/gems/logstash-input-beats-3.1.23-java/vendor/jar-dependencies/io/netty/netty-all/4.1.3.Final/netty-all-4.1.3.Final.jar
-```
-
 - Configration
 ```
 e.g.
@@ -54,22 +58,21 @@ output {
     pravega {
       pravega_endpoint => "tcp://<host>:<port>"
       stream_name => "myStream"
-      scope => "myScope"
-      #username => "admin"
-      #password => "1111_aaaa"
     }
   }
 }
 ```
 ```
-  # other optional configs
+  # other optional configs. When the controller authorization of pravega is open, the usename and password is required.
 
-  codec:           default 'json'
-  num_of_segments: default 1
-  routing_key    : default ""
+      scope:             default: 'global'
+      num_of_segments:   default: 1
+      routing_key:       default: ""
+      username:          default: ""
+      password:          default: ""
 ```
 
-- [Re]start logstash
+- Restart logstash
 
 ## Developing
 
@@ -88,13 +91,11 @@ bundle install
 #### Test
 
 - Update your dependencies
-
 ```sh
 bundle install
 ```
 
 - Run tests
-
 ```sh
 bundle exec rspec
 ```

--- a/lib/logstash/outputs/pravega.rb
+++ b/lib/logstash/outputs/pravega.rb
@@ -3,6 +3,7 @@ require "logstash/outputs/base"
 require "logstash/namespace"
 require "java"
 require "logstash-output-pravega_jars.rb"
+require "json"
 
 class LogStash::Outputs::Pravega < LogStash::Outputs::Base
   declare_threadsafe!
@@ -25,72 +26,71 @@ class LogStash::Outputs::Pravega < LogStash::Outputs::Base
 
   config :password, :validate => :string, :default => ""
 
-
   public
   def register
-    create_stream
-    logger.debug("created stream successfully", :stream => @stream_name)
-    @producer = create_producer
   end # def register
 
   public
   def multi_receive_encoded(encoded)
+    pre_check(encoded)
+    @producer = create_producer
     encoded.each do |event,data|
       begin
         @producer.writeEvent(routing_key,data)
-        logger.debug("write in stream succssfully", :stream_name => @stream_name, :event => data)
+	logger.debug("write in stream succssfully", :stream_name => @stream_name, :event => data)
       rescue LogStash::ShutdownSignal
         logger.debug("Pravega producer got shutdown signal")
       rescue => e
         logger.warn("Pravega producer threw exception, restarting", :exception => e)
       end
     end
-  end
-
-
-  def close
-    @producer.close
+    @producer.close()
   end
 
   private
-  def create_stream
-    begin
-        java_import("io.pravega.client.admin.StreamManager")
-        java_import("io.pravega.client.admin.impl.StreamManagerImpl")
-        java_import("io.pravega.client.stream.impl.Controller")
-        java_import("io.pravega.client.stream.impl.ControllerImpl")
-        java_import("io.pravega.client.stream.ScalingPolicy")
-        java_import("io.pravega.client.stream.StreamConfiguration")
-        java_import("io.pravega.client.ClientConfig")
-        java_import("io.pravega.client.stream.impl.DefaultCredentials")
-        uri = java.net.URI.new(pravega_endpoint)
-        clientConfig = ClientConfig.builder()
-                                   .controllerURI(uri)
-                                   .credentials(DefaultCredentials.new(password, username))
-                                   .validateHostName(false)
-                                   .build()
-        streamManager = StreamManager.create(clientConfig)
-        streamManager.createScope(scope)
-        policy = ScalingPolicy.fixed(num_of_segments)
-        streamConfig = StreamConfiguration.builder().scalingPolicy(policy).build()
-        streamManager.createStream(scope, stream_name, streamConfig)
+  def pre_check(encoded)
+    # If the num_of_segment <= 0, the IllegalArgumentException will be thrown and logstash will stop.
+    @num_of_segments = 1 if @num_of_segments <= 0
+
+    # If the input stream name is same as output, it will filter the formatted json data again and again without endless.
+    # So, the new output streamName needs to be created
+    encoded.each do |event, data|
+      if @stream_name == JSON.parse(data)['streamName']
+        @stream_name = "newOutputStream-".concat(SecureRandom.uuid)
+	logger.info("The input stream_name shouldn't be equal to output, the new output_stream is created", :stream_name => @stream_name)
+	break
+      end
     end
+    logger.debug("After arugument preCheck ", :num_of_segments => @num_of_segments, :stream_name => @stream_name)
   end
 
   private
   def create_producer
     begin
-        java_import("io.pravega.client.ClientFactory")
-        java_import("io.pravega.client.stream.impl.JavaSerializer")
-        java_import("io.pravega.client.stream.EventWriterConfig")
-        uri = java.net.URI.new(pravega_endpoint)
-        clientConfig = ClientConfig.builder()
-                                   .controllerURI(uri)
-                                   .credentials(DefaultCredentials.new(password, username))
-                                   .validateHostName(false)
-                                   .build()
-        clientFactory = ClientFactory.withScope(scope, clientConfig)
-        writer = clientFactory.createEventWriter(stream_name, JavaSerializer.new(), EventWriterConfig.builder().build()) 
+      java_import("io.pravega.client.admin.StreamManager")
+      java_import("io.pravega.client.stream.ScalingPolicy")
+      java_import("io.pravega.client.stream.StreamConfiguration")
+      java_import("io.pravega.client.ClientConfig")
+      java_import("io.pravega.client.stream.impl.DefaultCredentials")
+      java_import("io.pravega.client.ClientFactory")
+      java_import("io.pravega.client.stream.impl.JavaSerializer")
+      java_import("io.pravega.client.stream.EventWriterConfig")
+
+      uri = java.net.URI.new(pravega_endpoint)
+      clientConfig = ClientConfig.builder()
+                                 .controllerURI(uri)
+                                 .credentials(DefaultCredentials.new(password, username))
+                                 .validateHostName(false)
+                                 .build()
+      streamManager = StreamManager.create(clientConfig)
+      streamManager.createScope(scope)
+      policy = ScalingPolicy.fixed(@num_of_segments)
+      streamConfig = StreamConfiguration.builder().scalingPolicy(policy).build()
+      streamManager.createStream(scope, stream_name, streamConfig)
+      logger.debug("created stream successfully", :stream => @stream_name)
+
+      clientFactory = ClientFactory.withScope(scope, clientConfig)
+      writer = clientFactory.createEventWriter(stream_name, JavaSerializer.new(), EventWriterConfig.builder().build())
     end
   end
 end # class LogStash::Outputs::Pravega

--- a/logstash-output-pravega.gemspec
+++ b/logstash-output-pravega.gemspec
@@ -1,15 +1,15 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-output-pravega'
-  s.version       = '0.3.0-SNAPSHOT'
+  s.version       = '0.4.0'
   s.licenses      = ['Apache License (2.0)']
   s.summary       = 'Output events to a Pravega Stream. This uses the Pravega Writer API to write event to a stream on the Pravega'
   s.description   = 'This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program'
-  s.authors       = ['Ben Wang', 'Tony Li']
+  s.authors       = ['Ben Wang', 'Tony Li', 'Lingling.Yao']
   s.email         = 'ben.wang@emc.com'
   s.require_paths = ['lib']
 
   # Files
-  s.files = Dir["lib/**/*.rb","spec/**/*","*.gemspec","*.md","CONTRIBUTORS","Gemfile","LICENSE","NOTICE.TXT", "vendor/jar-dependencies/**/*.jar", "vendor/jar-dependencies/**/*.rb"]
+  s.files = Dir["lib/**/*.rb","spec/**/*","*.gemspec","*.md","CONTRIBUTORS","Gemfile","LICENSE","NOTICE.TXT", "vendor/jar-dependencies/**/*"]
 
    # Tests
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   # Special flag to let us know this is actually a logstash plugin
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
-  s.requirements << "jar 'io.pravega:pravega-client', '0.3.0-64.d0c8497-SNAPSHOT'"
+  s.requirements << "jar 'io.pravega:pravega-client', '0.4.0'"
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
@@ -25,4 +25,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'stud', '>= 0.0', '>= 0.0.22'
   s.add_development_dependency 'logstash-devutils', '>= 0.0', '>= 0.0.16'
   s.add_development_dependency 'jar-dependencies', '>= 0.3.2'
+  s.add_development_dependency 'json', '>= 1.8.3'
 end

--- a/pom.xml
+++ b/pom.xml
@@ -8,18 +8,8 @@
     <dependency>
       <groupId>io.pravega</groupId>
       <artifactId>pravega-client</artifactId>
-      <version>0.3.0-64.d0c8497-SNAPSHOT</version>
+      <version>0.4.0</version>
     </dependency>
   </dependencies>
-  <repositories>
-    <repository>
-      <id>sonatype</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </repository>
-    <repository>
-      <id>jfrog</id>
-      <url>https://oss.jfrog.org/artifactory/jfrog-dependencies</url>
-    </repository>
-  </repositories>
 </project>
 


### PR DESCRIPTION
**Code Changes**

- Switch the version of pravega-client API to 0.4.0
- Fix some bugs of the old version
    - Add the argument precheck for output plugin
    - Fix the unnecessary filter again when input_stream is same as outout_stream
    - Fix the bug of writer which can't handle the next round of data ingestion.