### PR TITLE
logstash-output plugin - added support to SDP

### DIFF
--- a/logstash-output-pravega.gemspec
+++ b/logstash-output-pravega.gemspec
@@ -16,8 +16,9 @@ Gem::Specification.new do |s|
 
   # Special flag to let us know this is actually a logstash plugin
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
-  #s.requirements << "jar 'io.pravega:pravega-keycloak-client', '0.6.0'"
   s.requirements << "jar 'io.pravega:pravega-client', '0.8.0'"
+
+  s.requirements << "jar 'io.pravega:pravega-keycloak-client', '0.8.0'"
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"

--- a/pom.xml
+++ b/pom.xml
@@ -38,12 +38,12 @@
       <artifactId>pravega-client</artifactId>
       <version>0.8.0</version>
     </dependency>
-<!--
+
     <dependency>
       <groupId>io.pravega</groupId>
       <artifactId>pravega-keycloak-client</artifactId>
-      <version>0.6.0</version>
-    </dependency> -->
+      <version>0.8.0</version>
+    </dependency>
   </dependencies>
 </project>
 


### PR DESCRIPTION
Problem:
At present logstash output connector supports only pravega and needs SDP support for customers

**Solution:**
Enhanced support to SDP.

**Testing:**
Tested on local environment and validated.