### PR TITLE
Added SDP platform support to logstash output connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,18 @@ e.g.
 output {
     pravega {
       pravega_endpoint => "tcp://<host>:<port>"
+      create_scope => false
+      scope => "demo"
       stream_name => "myStream"
     }
   }
 }
 ```
+- Add ENVIRONMENT Variables
+export pravega_client_auth_method=Bearer
+export pravega_client_auth_loadDynamic=true 
+export KEYCLOAK_SERVICE_ACCOUNT_FILE=/PATH_TO_KEYCLOAK_FILE/keycloak-demo.json
+
 ```
   # other optional configs. When the controller authorization of pravega is open, the usename and password is required.
 

--- a/logstash-output-pravega.gemspec
+++ b/logstash-output-pravega.gemspec
@@ -16,8 +16,9 @@ Gem::Specification.new do |s|
 
   # Special flag to let us know this is actually a logstash plugin
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
-  #s.requirements << "jar 'io.pravega:pravega-keycloak-client', '0.6.0'"
   s.requirements << "jar 'io.pravega:pravega-client', '0.8.0'"
+
+  s.requirements << "jar 'io.pravega:pravega-keycloak-client', '0.8.0'"
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"

--- a/pom.xml
+++ b/pom.xml
@@ -38,12 +38,12 @@
       <artifactId>pravega-client</artifactId>
       <version>0.8.0</version>
     </dependency>
-<!--
+
     <dependency>
       <groupId>io.pravega</groupId>
       <artifactId>pravega-keycloak-client</artifactId>
-      <version>0.6.0</version>
-    </dependency> -->
+      <version>0.8.0</version>
+    </dependency>
   </dependencies>
 </project>
 


### PR DESCRIPTION
**Problem:**
At present logstash output connector supports only pravega and needs SDP support for customers

**Solution:**
Enhanced support to SDP.

**Testing:**
Tested on local environment and validated.